### PR TITLE
 Fix Typo in `README.md`

### DIFF
--- a/nekoyume/Assets/ExternalDependencyManager/Editor/README.md
+++ b/nekoyume/Assets/ExternalDependencyManager/Editor/README.md
@@ -454,7 +454,7 @@ In order to modify the generated Podfile you can create a script like this:
 ```
 using System.IO;
 public class PostProcessIOS : MonoBehaviour {
-[PostProcessBuildAttribute(45)]//must be between 40 and 50 to ensure that it's not overriden by Podfile generation (40) and that it's added before "pod install" (50)
+[PostProcessBuildAttribute(45)]//must be between 40 and 50 to ensure that it's not overridden by Podfile generation (40) and that it's added before "pod install" (50)
 private static void PostProcessBuild_iOS(BuildTarget target, string buildPath)
 {
     if (target == BuildTarget.iOS)


### PR DESCRIPTION
# Fix Typo in `README.md`

## Description
This pull request resolves a typo in the `README.md` file within the `nekoyume/Assets/ExternalDependencyManager/Editor` directory.  
- Corrected the spelling of "overriden" to "overridden" in the code comment.

### Changes Made:
- **File Modified:** `nekoyume/Assets/ExternalDependencyManager/Editor/README.md`
- **Summary of Changes:**
  - Line 454: Corrected "overriden" to "overridden."

## Related Issues
<!-- If applicable, link to any issues this PR addresses. -->
N/A

## Checklist
- [x] Code comments updated for clarity and professionalism.
- [x] Verified adherence to the project's [GitHub Community Guidelines](link-to-guidelines).

## Testing
<!-- Describe how you validated the change, if applicable. -->
- N/A (Comment typo fix only)

## Additional Notes
This update is a non-functional change and is strictly related to improving the clarity and accuracy of the documentation.

---

**Allow edits by maintainers:** [x]  
<!-- Check this 
